### PR TITLE
Replace "Nagios::Plugin" with "Monitoring::Plugin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ derived from another one that was published under a different license.
 Dependencies
 ------------
 
-All Perl-based plugins will require Nagios::Plugin at the very least,
+All Perl-based plugins will require Monitoring::Plugin at the very least,
 as that implements the basic Nagios API in a flexible way.
 
  * `check_smart.pl`

--- a/gentoo/check_openrc.pl
+++ b/gentoo/check_openrc.pl
@@ -36,7 +36,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =cut
 
 use strict;
-use Nagios::Plugin;
+use Monitoring::Plugin;
 
 my $LICENSE = <<END;
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -48,7 +48,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END
 
-my $np = Nagios::Plugin->new( shortname => "OPENRC",
+my $np = Monitoring::Plugin->new( shortname => "OPENRC",
 			      usage => "Usage: %s [--stopped-critical] <list of runlevels>",
 			      blurb => "Check services status on OpenRC",
 			      license => $LICENSE,

--- a/gentoo/check_portage_age.pl
+++ b/gentoo/check_portage_age.pl
@@ -37,7 +37,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =cut
 
 use strict;
-use Nagios::Plugin;
+use Monitoring::Plugin;
 use Date::Parse;
 use Time::Duration;
 
@@ -51,7 +51,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END
 
-my $np = Nagios::Plugin->new( shortname => "PORTAGE_AGE",
+my $np = Monitoring::Plugin->new( shortname => "PORTAGE_AGE",
 			      usage => "Usage: %s -w SECONDS -c SECONDS",
 			      blurb => "Check Portage tree age (last sync)",
 			      license => $LICENSE,

--- a/network/check_smb_share.pl
+++ b/network/check_smb_share.pl
@@ -38,7 +38,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =cut
 
 use strict;
-use Nagios::Plugin;
+use Monitoring::Plugin;
 use Filesys::SmbClient;
 
 my $LICENSE = <<END;
@@ -51,7 +51,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END
 
-my $np = Nagios::Plugin->new( shortname => "SMB SHARE",
+my $np = Monitoring::Plugin->new( shortname => "SMB SHARE",
 			      usage => "Usage: %s [-u USERNAME] [-p PASSWORD] [-w WORKGROUP] -H HOSTNAME [-P PATH] [-W] [-D] SHARE",
 			      blurb => "Check for accessibility of SMB shares",
 			      license => $LICENSE,

--- a/system/check_smart.pl
+++ b/system/check_smart.pl
@@ -39,7 +39,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =cut
 
 use strict;
-use Nagios::Plugin;
+use Monitoring::Plugin;
 
 my $LICENSE = <<END;
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -51,7 +51,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END
 
-my $np = Nagios::Plugin->new( shortname => "SMART",
+my $np = Monitoring::Plugin->new( shortname => "SMART",
 			      usage => "Usage: %s [--sudo] [--smartctl PATH] [--device TYPE] device",
 			      blurb => "Check health status of S.M.A.R.T. drives",
 			      license => $LICENSE,


### PR DESCRIPTION
As this basically is an upstream renaming of the package to avoid
trademark issues, drop-in substitution is satisfactory.

Closes https://github.com/Flameeyes/nagios-plugins-flameeyes/issues/1

Bug: https://bugs.gentoo.org/608224